### PR TITLE
tighter inequality for bug

### DIFF
--- a/certora/spec/ERC20.spec
+++ b/certora/spec/ERC20.spec
@@ -71,7 +71,7 @@ rule transferReverts {
 rule transferDoesntRevert {
     env e; address recipient; uint amount;
 
-    require balanceOf(e.msg.sender) > amount;
+    require balanceOf(e.msg.sender) >= amount;
     require e.msg.value == 0;
     require balanceOf(recipient) + amount < max_uint;
     require e.msg.sender != 0;


### PR DESCRIPTION
Added a tighter requirement for transfer revert condition - now we also expect transfer to work if the user exactly the amount of token they wish to transfer. I need this fix for the video for Istanbul