### PR TITLE
remove reference to increaseAllowance

### DIFF
--- a/certora/spec/ERC20.spec
+++ b/certora/spec/ERC20.spec
@@ -90,7 +90,7 @@ rule onlyHolderCanChangeAllowance {
 
     mathint allowance_before = allowance(holder, spender);
 
-    method f; env e; calldataarg args; // was: env e; uint256 amount;
+    method f; env e; uint256 amount;
     approve(e, spender, amount);
 
     mathint allowance_after = allowance(holder, spender);


### PR DESCRIPTION
Removed reference to the function `increaseAllowance` in the `ERC20.spec`.
The function `increaseAllowance` is not a standard ERC20 function (see list here https://ethereum.org/developers/docs/standards/tokens/erc-20). It created a bad error message on m0's code when Jared tried to run the rule on their code, which had an ERC20 that did not contain this function: 
`[main] ERROR ALWAYS - Error in spec file (ERC20.spec:102:80): could not type expression "sig:MToken.increaseAllowance(address, uint256)", message: could not find method`
https://prover.certora.com/output/7053/8a687fb3ff0e4b06b5c357738a5e8340/?anonymousKey=5cb589114f221eaf6c38bde67e7824d55686a0f5

As we want this spec to be generic, I am removing the reference to this function.